### PR TITLE
Fix workloop issue

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -18,6 +18,7 @@ OSDefineMetaClassAndStructors(VoodooI2CControllerDriver, IOService);
 
 void VoodooI2CControllerDriver::free() {
     OSSafeReleaseNULL(device_nubs);
+    OSSafeReleaseNULL(work_loop);
 
     super::free();
 }
@@ -110,6 +111,10 @@ exit:
     nub->enableInterrupt(0);
 }
 
+IOWorkLoop* VoodooI2CControllerDriver::getWorkLoop(void) const {
+    return work_loop;
+}
+
 bool VoodooI2CControllerDriver::init(OSDictionary* properties) {
     if (!super::init(properties))
         return false;
@@ -118,6 +123,11 @@ bool VoodooI2CControllerDriver::init(OSDictionary* properties) {
     bus_device.awake = true;
 
     device_nubs = OSArray::withCapacity(1);
+
+    work_loop = IOWorkLoop::workLoop();
+    if (!work_loop) {
+        return false;
+    }
 
     return true;
 }
@@ -365,7 +375,6 @@ void VoodooI2CControllerDriver::releaseResources() {
     }
 
     OSSafeReleaseNULL(command_gate);
-    OSSafeReleaseNULL(work_loop);
 
     if (i2c_bus_lock) {
         IOLockFree(i2c_bus_lock);
@@ -441,14 +450,6 @@ bool VoodooI2CControllerDriver::start(IOService* provider) {
         IOLog("%s::%s Could not allocate I2C bus lock\n", getName(), bus_device.name);
         goto exit;
     }
-
-    work_loop = getWorkLoop();
-    if (!work_loop) {
-        IOLog("%s::%s Could not get work loop\n", getName(), bus_device.name);
-        goto exit;
-    }
-
-    work_loop->retain();
 
     command_gate = IOCommandGate::commandGate(this);
     if (!command_gate || (work_loop->addEventSource(command_gate) != kIOReturnSuccess)) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -144,9 +144,17 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
 
     IOReturn transferI2C(VoodooI2CControllerBusMessage* messages, int number);
 
+    /* Gets an *IOWorkLoop* object
+     *
+     * This function returns the existing workloop. This workloop is intended to be used by
+     * the controller itself along with any drivers that attach to it.
+     * @return A pointer to an *IOWorkLoop* object, else *NULL*
+     */
+    IOWorkLoop* getWorkLoop(void) const override;
+
  private:
     IOCommandGate* command_gate;
-    IOWorkLoop* work_loop;
+    IOWorkLoop* work_loop = nullptr;
     IOLock* i2c_bus_lock = nullptr;
     bool is_interrupt_registered = false;
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -165,10 +165,6 @@ IOReturn VoodooI2CDeviceNub::getInterruptType(int source, int* interrupt_type) {
     }
 }
 
-IOWorkLoop* VoodooI2CDeviceNub::getWorkLoop(void) const {
-    return work_loop;
-}
-
 IOReturn VoodooI2CDeviceNub::readI2C(UInt8* values, UInt16 length) {
     return command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &VoodooI2CDeviceNub::readI2CGated), values, &length);
 }
@@ -214,12 +210,14 @@ bool VoodooI2CDeviceNub::start(IOService* provider) {
     if (!super::start(provider))
         return false;
 
-    work_loop = IOWorkLoop::workLoop();
+    work_loop = getWorkLoop();
 
     if (!work_loop) {
         IOLog("%s Could not get work loop\n", getName());
         goto exit;
     }
+
+    work_loop->retain();
 
     command_gate = IOCommandGate::commandGate(this);
     if (!command_gate || (work_loop->addEventSource(command_gate) != kIOReturnSuccess)) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -166,26 +166,7 @@ IOReturn VoodooI2CDeviceNub::getInterruptType(int source, int* interrupt_type) {
 }
 
 IOWorkLoop* VoodooI2CDeviceNub::getWorkLoop(void) const {
-    // 0x00000000 = not initialized. 0x00000001 = busy. 0xXXXXXXXX = initialized.
-    static IOWorkLoop* __work_loop = NULL;
-
-    // Do we have a work loop already?, if so return it NOW.
-    if ((vm_address_t) __work_loop >> 1)
-        return __work_loop;
-
-    if (OSCompareAndSwap(0, 1, reinterpret_cast<IOWorkLoop*>(&__work_loop))) {
-        // Construct the workloop and set the __work_loop variable
-        // to whatever the result is and return
-        __work_loop = IOWorkLoop::workLoop();
-    } else {
-        while (reinterpret_cast<IOWorkLoop*>(__work_loop) == reinterpret_cast<IOWorkLoop*>(1)) {
-            // Spin around the __work_loop variable until the
-            // initialization finishes.
-            thread_block(0);
-        }
-    }
-
-    return __work_loop;
+    return work_loop;
 }
 
 IOReturn VoodooI2CDeviceNub::readI2C(UInt8* values, UInt16 length) {
@@ -233,14 +214,12 @@ bool VoodooI2CDeviceNub::start(IOService* provider) {
     if (!super::start(provider))
         return false;
 
-    work_loop = getWorkLoop();
+    work_loop = IOWorkLoop::workLoop();
 
     if (!work_loop) {
         IOLog("%s Could not get work loop\n", getName());
         goto exit;
     }
-
-    work_loop->retain();
 
     command_gate = IOCommandGate::commandGate(this);
     if (!command_gate || (work_loop->addEventSource(command_gate) != kIOReturnSuccess)) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -176,7 +176,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     UInt8 i2c_address;
     bool has_gpio_interrupts;
     bool use_10bit_addressing;
-    IOWorkLoop* work_loop;
+    IOWorkLoop* work_loop = nullptr;
 
     /* Instantiates a <VoodooI2CACPICRSParser> object to grab I2C slave properties as well as potential GPIO interrupt properties.
      *

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -81,14 +81,6 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
 
     IOReturn getInterruptType(int source, int *interruptType) override;
 
-    /* Gets an *IOWorkLoop* object
-     *
-     * This function either grabs the existing workloop or creates a new one if none is found. This workloop is intended to be used by
-     * the nub itself along with any drivers that attach to it.
-     * @return A pointer to an *IOWorkLoop* object, else *NULL*
-     */
-    IOWorkLoop* getWorkLoop(void) const override;
-
     /* Transmits an I2C read request to the slave device
      * @values The buffer that the returned data is to be written into
      * @length The length of the message


### PR DESCRIPTION
Fix the pin 28 error by removing the buggy static workloop instance.

The `__work_loop` in `VoodooI2CDeviceNub::getWorkLoop()` is declared as a static var, so it will be shared by all the I2CHIDDevice instances of different devices, like the touchpad and touchscreen. The error started to show up since v2.4.2 because the GPIO interrupt is managed by the `IOInterruptEventSource` of `I2CHIDDevice` via the nub `VoodooI2CDeviceNub`.