### PR TITLE
Revert part of "Fix workloop issue (#320)"

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.hpp
@@ -144,14 +144,6 @@ class EXPORT VoodooI2CControllerDriver : public IOService {
 
     IOReturn transferI2C(VoodooI2CControllerBusMessage* messages, int number);
 
-    /* Gets an *IOWorkLoop* object
-     *
-     * This function returns the existing workloop. This workloop is intended to be used by
-     * the controller itself along with any drivers that attach to it.
-     * @return A pointer to an *IOWorkLoop* object, else *NULL*
-     */
-    IOWorkLoop* getWorkLoop(void) const override;
-
  private:
     IOCommandGate* command_gate;
     IOWorkLoop* work_loop = nullptr;

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -165,6 +165,10 @@ IOReturn VoodooI2CDeviceNub::getInterruptType(int source, int* interrupt_type) {
     }
 }
 
+IOWorkLoop* VoodooI2CDeviceNub::getWorkLoop(void) const {
+    return work_loop;
+}
+
 IOReturn VoodooI2CDeviceNub::readI2C(UInt8* values, UInt16 length) {
     return command_gate->attemptAction(OSMemberFunctionCast(IOCommandGate::Action, this, &VoodooI2CDeviceNub::readI2CGated), values, &length);
 }
@@ -210,14 +214,12 @@ bool VoodooI2CDeviceNub::start(IOService* provider) {
     if (!super::start(provider))
         return false;
 
-    work_loop = getWorkLoop();
+    work_loop = IOWorkLoop::workLoop();
 
     if (!work_loop) {
         IOLog("%s Could not get work loop\n", getName());
         goto exit;
     }
-
-    work_loop->retain();
 
     command_gate = IOCommandGate::commandGate(this);
     if (!command_gate || (work_loop->addEventSource(command_gate) != kIOReturnSuccess)) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -81,6 +81,14 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
 
     IOReturn getInterruptType(int source, int *interruptType) override;
 
+    /* Gets an *IOWorkLoop* object
+     *
+     * This function either grabs the existing workloop or creates a new one if none is found. This workloop is intended to be used by
+     * the nub itself along with any drivers that attach to it.
+     * @return A pointer to an *IOWorkLoop* object, else *NULL*
+     */
+    IOWorkLoop* getWorkLoop(void) const override;
+
     /* Transmits an I2C read request to the slave device
      * @values The buffer that the returned data is to be written into
      * @length The length of the message


### PR DESCRIPTION
This commit reverts part of previous commit "Fix workloop issue (#320)" 54c7264e94d201da914bb324264c3e625753167b to fix a deadlock issue. https://github.com/VoodooI2C/VoodooI2C/issues/282#issuecomment-629925832

Revert:
- Move workloop allocation to I2CControllerDriver