### PR TITLE
Minor fixes of power state switching in setPowerState()

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
@@ -28,7 +28,7 @@ IOReturn VoodooI2CACPIController::setPowerState(unsigned long whichState, IOServ
     if (whatDevice != this)
         return kIOPMAckImplied;
 
-    if (whichState == kIOPMPowerOff) {
+    if (whichState == 0) {  // index of kIOPMPowerOff state in VoodooI2CIOPMPowerStates
         physical_device.awake = false;
         unmapMemory();
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CACPIController.cpp
@@ -29,12 +29,12 @@ IOReturn VoodooI2CACPIController::setPowerState(unsigned long whichState, IOServ
         return kIOPMAckImplied;
 
     if (whichState == 0) {  // index of kIOPMPowerOff state in VoodooI2CIOPMPowerStates
-        physical_device.awake = false;
-        unmapMemory();
-
-        setACPIPowerState(kVoodooI2CStateOff);
-
-        IOLog("%s::%s Going to sleep\n", getName(), physical_device.name);
+        if (physical_device.awake) {
+            physical_device.awake = false;
+            unmapMemory();
+            setACPIPowerState(kVoodooI2CStateOff);
+            IOLog("%s::%s Going to sleep\n", getName(), physical_device.name);
+        }
     } else {
         if (!physical_device.awake) {
             setACPIPowerState(kVoodooI2CStateOn);

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -415,10 +415,12 @@ IOReturn VoodooI2CControllerDriver::setPowerState(unsigned long whichState, IOSe
     // Ensure we are not in the middle of a i2c session.
     IOLockLock(i2c_bus_lock);
     if (whichState == 0) {  // index of kIOPMPowerOff state in VoodooI2CIOPMPowerStates
-        bus_device.awake = false;
-        toggleBusState(kVoodooI2CStateOff);
-        stopI2CInterrupt();
-        IOLog("%s::%s Going to sleep\n", getName(), bus_device.name);
+        if (bus_device.awake) {
+            bus_device.awake = false;
+            toggleBusState(kVoodooI2CStateOff);
+            stopI2CInterrupt();
+            IOLog("%s::%s Going to sleep\n", getName(), bus_device.name);
+        }
     } else {
         if (!bus_device.awake) {
             toggleBusState(kVoodooI2CStateOn);

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -511,7 +511,9 @@ void VoodooI2CControllerDriver::stop(IOService* provider) {
 
     OSSafeReleaseNULL(device_nubs);
 
-    toggleBusState(kVoodooI2CStateOff);
+    if (bus_device.awake) {
+        toggleBusState(kVoodooI2CStateOff);
+    }
 
     releaseResources();
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -414,7 +414,7 @@ IOReturn VoodooI2CControllerDriver::setPowerState(unsigned long whichState, IOSe
 
     // Ensure we are not in the middle of a i2c session.
     IOLockLock(i2c_bus_lock);
-    if (!whichState) {
+    if (whichState == 0) {  // index of kIOPMPowerOff state in VoodooI2CIOPMPowerStates
         bus_device.awake = false;
         toggleBusState(kVoodooI2CStateOff);
         stopI2CInterrupt();

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
@@ -78,7 +78,7 @@ IOReturn VoodooI2CPCIController::setPowerState(unsigned long whichState, IOServi
     if (whatDevice != this)
         return kIOPMAckImplied;
 
-    if (whichState == kIOPMPowerOff) {
+    if (whichState == 0) {  // index of kIOPMPowerOff state in VoodooI2CIOPMPowerStates
         physical_device.awake = false;
         unmapMemory();
         IOLog("%s::%s Going to sleep\n", getName(), physical_device.name);

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
@@ -79,9 +79,11 @@ IOReturn VoodooI2CPCIController::setPowerState(unsigned long whichState, IOServi
         return kIOPMAckImplied;
 
     if (whichState == 0) {  // index of kIOPMPowerOff state in VoodooI2CIOPMPowerStates
-        physical_device.awake = false;
-        unmapMemory();
-        IOLog("%s::%s Going to sleep\n", getName(), physical_device.name);
+        if (physical_device.awake) {
+            physical_device.awake = false;
+            unmapMemory();
+            IOLog("%s::%s Going to sleep\n", getName(), physical_device.name);
+        }
     } else {
         if (!physical_device.awake) {
             configurePCI();


### PR DESCRIPTION
- Correct the usages of `whichState` parameter in `setPowerState()`. The parameter `whichState` in `setPowerState()` is the index number in the registered power state array, not the power state value, though they are both 0 in the case of `kIOPMPowerOff`.

```cpp
/*! @function setPowerState
 *   @abstract Requests a power managed driver to change the power state of its device.
 *   @discussion A power managed driver must override <code>setPowerState</code> to take part in system power management. After a driver is registered with power management, the system uses <code>setPowerState</code> to power the device off and on for system sleep and wake.
 *   Calls to @link PMinit PMinit@/link and @link registerPowerDriver registerPowerDriver@/link enable power management to change a device's power state using <code>setPowerState</code>. <code>setPowerState</code> is called in a clean and separate thread context.
 *   @param powerStateOrdinal The number in the power state array of the state the driver is being instructed to switch to.
 *   @param whatDevice A pointer to the power management object which registered to manage power for this device. In most cases, <code>whatDevice</code> will be equal to your driver's own <code>this</code> pointer.
 *   @result The driver must return <code>IOPMAckImplied</code> if it has complied with the request when it returns. Otherwise if it has started the process of changing power state but not finished it, the driver should return a number of microseconds which is an upper limit of the time it will need to finish. Then, when it has completed the power switch, it should call @link acknowledgeSetPowerState acknowledgeSetPowerState@/link. */

	virtual IOReturn setPowerState(
		unsigned long powerStateOrdinal,
		IOService *   whatDevice );
```

- Fix potential re-entrancy of the sleep state in `::setPowerState()`.
- Guard I2C bus access in `::stop()` with a bus state check. Avoid access to the I2C bus after the device is powered off by the OS, which could happen when the driver fails to load.