### PR TITLE
Fixes VoodooInput compatibility 

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -78,7 +78,11 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
         freeFingerTypes[kMT2FingerTypeUndefined] = false;
     }
     
-    setThumbFingerType(&message);
+    // Fixes 2F taps as MT stack
+    if (event.contact_count > 2) {
+        setThumbFingerType(&message);
+    }
+    
     for(int i = 0; i < event.contact_count; i++) {
         VoodooInputTransducer* inputTransducer = &message.transducers[i];
         

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
@@ -29,6 +29,9 @@ class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
 
     bool lastIsForceClickEnabled = true;
     AbsoluteTime lastForceClickPropertyUpdateTime;
+    bool freeFingerTypes[kMT2FingerTypeCount];
+    MT2FingerType getFingerType(VoodooI2CDigitiserTransducer* transducer);
+    void setThumbFingerType(VoodooInputEvent* message);
 
     bool isForceClickEnabled();
  public:


### PR DESCRIPTION
Upstream changes in VoodooInput (https://github.com/acidanthera/VoodooInput/commit/835731a0e1547a62b645f4b49b4d3347d3f96dbe) breaks compatibility as the event fields are now changed.

This PR fixes that by assigning an unique finger value to each transducer (done so by transducer id).