### PR TITLE
Add Comet Lake H PCI IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following Intel I2C controllers are fully supported:
 4. `pci8086,a160` and `pci8086,a161` - Kaby Lake era
 5. `pci8086,9de8` and `pci8086,9de9` - Cannon Lake/Whiskey Lake era
 6. `pci8086,a368`, `pci8086,a369`, `pci8086,a36a` and `pci8086,a36b` - Coffee Lake era
-7. `pci8086,2e8` and `pci8086,2e9` - Comet Lake era
+7. `pci8086,2e8`,  `pci8086,2e9`, `pci8086,6e8` and `pci8086,6e9`- Comet Lake era
 
 The following device classes are fully supported:
 

--- a/VoodooI2C/VoodooI2C/Info.plist
+++ b/VoodooI2C/VoodooI2C/Info.plist
@@ -511,6 +511,8 @@
 			<key>IONameMatch</key>
 			<array>
 				<string>pci8086,34e8</string>
+				<string>pci8086,6e8</string>
+				<string>pci8086,6e9</string>
 				<string>pci8086,2e8</string>
 				<string>pci8086,2e9</string>
 				<string>pci8086,9d60</string>


### PR DESCRIPTION
Required by https://github.com/VoodooI2C/VoodooI2C/issues/334