### PR TITLE
Update VoodooI2CPCIController for newer Comet Lake PCI IDs

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
@@ -13,7 +13,7 @@ OSDefineMetaClassAndStructors(VoodooI2CPCIController, VoodooI2CController);
 
 void VoodooI2CPCIController::configurePCI() {
     char tmp[2];
-    const char kCometLakeflag[2] = {'2', 'e'};
+    const char kCometLakeflag[3] = {'2', '6', 'e'};
 
     IOLog("%s::%s Set PCI power state D0\n", getName(), physical_device.name);
     auto pci_device = physical_device.pci_device;
@@ -39,7 +39,8 @@ void VoodooI2CPCIController::configurePCI() {
     /* If it is Comet Lake, then let's apply Forcing D0 here.
        It will modify 0x80 below to your findings.*/
 
-    if (tmp[0] == kCometLakeflag[0] && tmp[1] == kCometLakeflag[1]) {
+    if ((tmp[0] == kCometLakeflag[0] || tmp[0] == kCometLakeFlag[1])
+        && tmp[1] == kCometLakeflag[2]) {
         IOLog("%s::%s Current CPU is Comet Lake, patching...\n", getName(), physical_device.name);
         uint16_t oldPowerStateWord = pci_device->configRead16(0x80 + 0x4);
         uint16_t newPowerStateWord = (oldPowerStateWord & (~0x3)) | 0x0;

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CPCIController.cpp
@@ -39,7 +39,7 @@ void VoodooI2CPCIController::configurePCI() {
     /* If it is Comet Lake, then let's apply Forcing D0 here.
        It will modify 0x80 below to your findings.*/
 
-    if ((tmp[0] == kCometLakeflag[0] || tmp[0] == kCometLakeFlag[1])
+    if ((tmp[0] == kCometLakeflag[0] || tmp[0] == kCometLakeflag[1])
         && tmp[1] == kCometLakeflag[2]) {
         IOLog("%s::%s Current CPU is Comet Lake, patching...\n", getName(), physical_device.name);
         uint16_t oldPowerStateWord = pci_device->configRead16(0x80 + 0x4);


### PR DESCRIPTION
This hacky patch should probably use something more reliable to determine if its a Comet Lake CPU, the initial check looked for Device ID's starting with `2e` however 2 new device ID's have since been added starting with `6e`.  Updated check here to look for `2e` or `6e`, which got it loading on my 10875H with device ID `6e8`