### PR TITLE
Notify multitouch engine when property changed

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -107,8 +107,7 @@ bool VoodooI2CNativeEngine::start(IOService* provider) {
     
     setProperty(VOODOO_INPUT_PHYSICAL_MAX_X_KEY, parentProvider->physical_max_x * 10, 32);
     setProperty(VOODOO_INPUT_PHYSICAL_MAX_Y_KEY, parentProvider->physical_max_y * 10, 32);
-    
-    setProperty(kIOFBTransformKey, 0ull, 32);
+
     setProperty("VoodooInputSupported", kOSBooleanTrue);
     
     stylus_check = 0;
@@ -150,6 +149,12 @@ bool VoodooI2CNativeEngine::isForceClickEnabled() {
 
     lastForceClickPropertyUpdateTime = now_abs;
     return lastIsForceClickEnabled;
+}
+
+void VoodooI2CNativeEngine::onPropertyChange() {
+    if (voodooInputInstance) {
+        super::messageClient(kIOMessageVoodooInputUpdatePropertiesNotification, voodooInputInstance);
+    }
 }
 
 void VoodooI2CNativeEngine::stop(IOService* provider) {

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
@@ -38,6 +38,7 @@ class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
     bool handleOpen(IOService *forClient, IOOptionBits options, void *arg) override;
     bool handleIsOpen(const IOService *forClient) const override;
     void handleClose(IOService *forClient, IOOptionBits options) override;
+    void onPropertyChange() override;
     
     MultitouchReturn handleInterruptReport(VoodooI2CMultitouchEvent event, AbsoluteTime timestamp);
  private:

--- a/Multitouch Support/VoodooI2CMultitouchEngine.cpp
+++ b/Multitouch Support/VoodooI2CMultitouchEngine.cpp
@@ -57,3 +57,7 @@ bool VoodooI2CMultitouchEngine::start(IOService* provider) {
 
     return true;
 }
+
+void VoodooI2CMultitouchEngine::onPropertyChange() {
+    return;
+}

--- a/Multitouch Support/VoodooI2CMultitouchEngine.hpp
+++ b/Multitouch Support/VoodooI2CMultitouchEngine.hpp
@@ -52,6 +52,8 @@ class EXPORT VoodooI2CMultitouchEngine : public IOService {
      */
 
     virtual bool start(IOService* provider);
+
+    virtual void onPropertyChange();
 };
 
 

--- a/Multitouch Support/VoodooI2CMultitouchInterface.cpp
+++ b/Multitouch Support/VoodooI2CMultitouchInterface.cpp
@@ -54,6 +54,18 @@ bool VoodooI2CMultitouchInterface::handleIsOpen(const IOService *forClient ) con
     return false;
 }
 
+bool VoodooI2CMultitouchInterface::setProperty(const OSSymbol* key, OSObject* object) {
+    bool result = super::setProperty(key, object);
+    if (result) {
+        for (int i = 0; i < engines->getCount(); i++) {
+            if (VoodooI2CMultitouchEngine* engine = OSDynamicCast(VoodooI2CMultitouchEngine, engines->getObject(i))) {
+                engine->onPropertyChange();
+            }
+        }
+    }
+    return result;
+}
+
 SInt8 VoodooI2CMultitouchInterface::orderEngines(VoodooI2CMultitouchEngine* a, VoodooI2CMultitouchEngine* b) {
     if (a->getScore() > b->getScore())
         return 1;

--- a/Multitouch Support/VoodooI2CMultitouchInterface.cpp
+++ b/Multitouch Support/VoodooI2CMultitouchInterface.cpp
@@ -55,15 +55,15 @@ bool VoodooI2CMultitouchInterface::handleIsOpen(const IOService *forClient ) con
 }
 
 bool VoodooI2CMultitouchInterface::setProperty(const OSSymbol* key, OSObject* object) {
-    bool result = super::setProperty(key, object);
-    if (result) {
-        for (int i = 0; i < engines->getCount(); i++) {
-            if (VoodooI2CMultitouchEngine* engine = OSDynamicCast(VoodooI2CMultitouchEngine, engines->getObject(i))) {
-                engine->onPropertyChange();
-            }
+    if (!super::setProperty(key, object)) {
+        return false;
+    }
+    for (int i = 0; i < engines->getCount(); i++) {
+        if (VoodooI2CMultitouchEngine* engine = OSDynamicCast(VoodooI2CMultitouchEngine, engines->getObject(i))) {
+            engine->onPropertyChange();
         }
     }
-    return result;
+    return true;
 }
 
 SInt8 VoodooI2CMultitouchInterface::orderEngines(VoodooI2CMultitouchEngine* a, VoodooI2CMultitouchEngine* b) {

--- a/Multitouch Support/VoodooI2CMultitouchInterface.hpp
+++ b/Multitouch Support/VoodooI2CMultitouchInterface.hpp
@@ -80,6 +80,9 @@ class EXPORT VoodooI2CMultitouchInterface : public IOService {
      */
     bool handleIsOpen(const IOService *forClient ) const override;
 
+    using IORegistryEntry::setProperty;
+    bool setProperty(const OSSymbol* key, OSObject* object) override;
+
     /* Orders engines according to <VoodooI2CMultitouchEngine::getScore>
      * @a The first engine in the comparison
      * @b The second engine in the comparison


### PR DESCRIPTION
- Remove a redundant fixed `IOFBTransform` property in `VoodooI2CNativeEngine`.
- Override `::setProperty()` for `MultitouchInterface` to notify engines on property change.
- Add `onPropertyChange()` method for `MultitouchEngine` to handle property change.