### PR TITLE
Attempt to get GPIO Interrupt from _DSM

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -116,7 +116,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
     data->release();
 
     if (!(availableIndex & (index << 1))) {
-        IOLog("%s::%s TP7D index 0x%x doesn't support GPIO report\n", controller_name, getName(), availableIndex);
+        IOLog("%s::%s TP7D doesn't support index 0x%x\n", controller_name, getName(), availableIndex);
         return kIOReturnUnsupportedMode;
     }
 
@@ -126,7 +126,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
 bool VoodooI2CDeviceNub::getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser) {
     OSObject *result;
     if (getDeviceResourcesDSM(TP7G_GPIO_INDEX, &result) != kIOReturnSuccess) {
-        IOLog("%s::%s Warning: If your chosen satellite implements polling then %s will run in polling mode.\n", controller_name, getName(), getName());
+        IOLog("%s::%s failed to retrieve GPIO interrupt from _DSM or XDSM\n", controller_name, getName());
         result->release();
         return false;
     }
@@ -147,7 +147,6 @@ bool VoodooI2CDeviceNub::getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs
         return false;
     }
 
-    has_gpio_interrupts = true;
     IOLog("%s::%s GPIO interrupts retrieved through _DSM method", controller_name, getName());
     return true;
 }

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -108,7 +108,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
     OSData *data = OSDynamicCast(OSData, *result);
 
     if (!data) {
-        IOLog("%s::%s Could not find or evaluate _DSM method for GPIO availability", controller_name, getName());
+        IOLog("%s::%s Could not get valid return from _DSM or XDSM method\n", controller_name, getName());
         return kIOReturnNotFound;
     }
 
@@ -116,7 +116,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
     data->release();
 
     if (!(availableIndex & (index << 1))) {
-        IOLog("%s::%s TP7D doesn't support index 0x%x\n", controller_name, getName(), availableIndex);
+        IOLog("%s::%s _DSM or XDSM method doesn't support TP7G index 0x%x\n", controller_name, getName(), availableIndex);
         return kIOReturnUnsupportedMode;
     }
 
@@ -126,14 +126,15 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
 bool VoodooI2CDeviceNub::getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser) {
     OSObject *result;
     if (getDeviceResourcesDSM(TP7G_GPIO_INDEX, &result) != kIOReturnSuccess) {
-        IOLog("%s::%s failed to retrieve GPIO interrupt from _DSM or XDSM\n", controller_name, getName());
+        IOLog("%s::%s failed to retrieve GPIO interrupt from _DSM or XDSM method\n", controller_name, getName());
         result->release();
         return false;
     }
 
     OSData *data = OSDynamicCast(OSData, result);
     if (!data) {
-        IOLog("%s::%s Could not get valid _DSM return for GPIO interrupt", controller_name, getName());
+        IOLog("%s::%s Could not get valid _DSM or XDSM return for GPIO interrupt\n", controller_name, getName());
+        result->release();
         return false;
     }
 
@@ -143,11 +144,11 @@ bool VoodooI2CDeviceNub::getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs
     data->release();
 
     if (!crs_parser->found_gpio_interrupts) {
-        IOLog("%s::%s Failed to find GPIO interrupt from _DSM", controller_name, getName());
+        IOLog("%s::%s Failed to find GPIO interrupt from _DSM or XDSM method\n", controller_name, getName());
         return false;
     }
 
-    IOLog("%s::%s GPIO interrupts retrieved through _DSM method", controller_name, getName());
+    IOLog("%s::%s GPIO interrupts retrieved through _DSM or XDSM method\n", controller_name, getName());
     return true;
 }
 
@@ -157,7 +158,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
 
     OSData *data = OSDynamicCast(OSData, result);
     if (!data) {
-        IOLog("%s::%s Could not find or evaluate _CRS method", controller_name, getName());
+        IOLog("%s::%s Could not find or evaluate _CRS method\n", controller_name, getName());
         return kIOReturnNotFound;
     }
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -123,17 +123,17 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
     return evaluateDSM(I2C_DSM_TP7G, index, result);
 }
 
-IOReturn VoodooI2CDeviceNub::getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser) {
+IOReturn VoodooI2CDeviceNub::getAlternativeInterrupt(VoodooI2CACPICRSParser* crs_parser) {
     OSObject *result = nullptr;
     if (getDeviceResourcesDSM(TP7G_GPIO_INDEX, &result) != kIOReturnSuccess) {
-        IOLog("%s::%s failed to retrieve GPIO interrupt from _DSM or XDSM method\n", controller_name, getName());
+        IOLog("%s::%s failed to retrieve interrupts from _DSM or XDSM method\n", controller_name, getName());
         result->release();
         return kIOReturnNotFound;
     }
 
     OSData *data = OSDynamicCast(OSData, result);
     if (!data) {
-        IOLog("%s::%s Could not get valid return for GPIO interrupt from _DSM or XDSM method\n", controller_name, getName());
+        IOLog("%s::%s Could not get valid return for interrupts from _DSM or XDSM method\n", controller_name, getName());
         result->release();
         return kIOReturnNotFound;
     }
@@ -144,11 +144,11 @@ IOReturn VoodooI2CDeviceNub::getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser*
     data->release();
 
     if (!crs_parser->found_gpio_interrupts) {
-        IOLog("%s::%s Failed to find GPIO interrupt from _DSM or XDSM method\n", controller_name, getName());
+        IOLog("%s::%s Failed to find valid interrupts from _DSM or XDSM method\n", controller_name, getName());
         return kIOReturnNotFound;
     }
 
-    IOLog("%s::%s GPIO interrupts retrieved from _DSM or XDSM method\n", controller_name, getName());
+    IOLog("%s::%s Found valid interrupts from _DSM or XDSM method\n", controller_name, getName());
     return kIOReturnSuccess;
 }
 
@@ -199,7 +199,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     }
 
     if (crs_parser.found_gpio_interrupts ||
-        (!validateInterrupt() && getAlternativeGPIOInterrupt(&crs_parser) == kIOReturnSuccess)) {
+        (!validateInterrupt() && getAlternativeInterrupt(&crs_parser) == kIOReturnSuccess)) {
         setProperty("gpioPin", crs_parser.gpio_interrupts.pin_number, 16);
         setProperty("gpioIRQ", crs_parser.gpio_interrupts.irq_type, 16);
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -38,6 +38,10 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
         return false;
     }
 
+    if (getHIDDescriptorAddress() != kIOReturnSuccess) {
+        IOLog("%s::%s Could not get device HID descriptor\n", controller_name, child->getName());
+    }
+
     if (has_gpio_interrupts) {
         gpio_controller = getGPIOController();
 
@@ -69,6 +73,134 @@ IOReturn VoodooI2CDeviceNub::enableInterrupt(int source) {
         return gpio_controller->enableInterrupt(gpio_pin);
     } else {
         return acpi_device->enableInterrupt(source);
+    }
+}
+
+IOReturn VoodooI2CDeviceNub::getHIDDescriptorAddress() {
+    uuid_t guid;
+    uuid_parse(I2C_DSM_HIDG, guid);
+
+    // convert to mixed-endian
+    *(reinterpret_cast<uint32_t *>(guid)) = OSSwapInt32(*(reinterpret_cast<uint32_t *>(guid)));
+    *(reinterpret_cast<uint16_t *>(guid) + 2) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(guid) + 2));
+    *(reinterpret_cast<uint16_t *>(guid) + 3) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(guid) + 3));
+
+    UInt32 result;
+    OSObject *params[4] = {
+        OSData::withBytes(guid, 16),
+        OSNumber::withNumber(0x1, 8),
+        OSNumber::withNumber(0x1, 8),
+        OSArray::withCapacity(1)
+    };
+    setProperty("HIDDescriptorAddress", false);
+
+    if (acpi_device->evaluateInteger("_DSM", &result, params, 4) != kIOReturnSuccess && acpi_device->evaluateInteger("XDSM", &result, params, 4) != kIOReturnSuccess) {
+        IOLog("%s::%s Could not find suitable _DSM or XDSM method in ACPI tables\n", controller_name, getName());
+        return kIOReturnNotFound;
+    }
+
+    setProperty("HIDDescriptorAddress", result, 32);
+
+    params[0]->release();
+    params[1]->release();
+    params[2]->release();
+    params[3]->release();
+
+    return kIOReturnSuccess;
+}
+
+IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM() {
+    uuid_t guid;
+    uuid_parse(I2C_DSM_TP7G, guid);
+
+    // convert to mixed-endian
+    *(reinterpret_cast<uint32_t *>(guid)) = OSSwapInt32(*(reinterpret_cast<uint32_t *>(guid)));
+    *(reinterpret_cast<uint16_t *>(guid) + 2) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(guid) + 2));
+    *(reinterpret_cast<uint16_t *>(guid) + 3) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(guid) + 3));
+
+    OSObject *result;
+    OSObject *params[4] = {
+        OSData::withBytes(guid, 16),
+        OSNumber::withNumber(0x1, 32),
+        OSNumber::withNumber((UInt32)0x0, 32),
+        OSArray::withCapacity(1)
+    };
+    setProperty("TP7GIndex", false);
+
+    if (acpi_device->evaluateObject("_DSM", &result, params, 4) != kIOReturnSuccess && acpi_device->evaluateObject("XDSM", &result, params, 4) != kIOReturnSuccess) {
+        IOLog("%s::%s Could not find suitable _DSM or XDSM method in ACPI tables\n", controller_name, getName());
+        return kIOReturnNotFound;
+    }
+
+    params[0]->release();
+    params[1]->release();
+    params[2]->release();
+    params[3]->release();
+
+    OSData *data = OSDynamicCast(OSData, result);
+
+    if (!data) {
+        IOLog("%s::%s Could not find or evaluate _DSM method for GPIO availability", controller_name, getName());
+        return kIOReturnNotFound;
+    }
+
+    UInt8 const* index = reinterpret_cast<UInt8 const*>(data->getBytesNoCopy());
+    setProperty("TP7GIndex", *index, 8);
+
+    return (*index & (1 << 1)) ? getDSMGPIOInterrupt() : kIOReturnUnsupportedMode;
+}
+
+IOReturn VoodooI2CDeviceNub::getDSMGPIOInterrupt() {
+    uuid_t guid;
+    uuid_parse(I2C_DSM_TP7G, guid);
+
+    // convert to mixed-endian
+    *(reinterpret_cast<uint32_t *>(guid)) = OSSwapInt32(*(reinterpret_cast<uint32_t *>(guid)));
+    *(reinterpret_cast<uint16_t *>(guid) + 2) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(guid) + 2));
+    *(reinterpret_cast<uint16_t *>(guid) + 3) = OSSwapInt16(*(reinterpret_cast<uint16_t *>(guid) + 3));
+
+    OSObject *result = NULL;
+    OSObject *params[4] = {
+        OSData::withBytes(guid, 16),
+        OSNumber::withNumber(0x1, 8),
+        OSNumber::withNumber(0x1, 8),
+        OSNumber::withNumber((UInt32)0x0, 8)
+    };
+
+    if (acpi_device->evaluateObject("_DSM", &result, params, 4) != kIOReturnSuccess && acpi_device->evaluateObject("XDSM", &result, params, 4) != kIOReturnSuccess) {
+        IOLog("%s::%s Could not find suitable _DSM or XDSM method in ACPI tables\n", controller_name, getName());
+        return kIOReturnNotFound;
+    }
+
+    params[0]->release();
+    params[1]->release();
+    params[2]->release();
+    params[3]->release();
+
+    OSData *data = OSDynamicCast(OSData, result);
+    if (!data) {
+        IOLog("%s::%s Could not find or evaluate _DSM method for GPIO", controller_name, getName());
+        return kIOReturnNotFound;
+    }
+
+    uint8_t const* crs = reinterpret_cast<uint8_t const*>(data->getBytesNoCopy());
+    VoodooI2CACPICRSParser crs_parser;
+    crs_parser.parseACPICRS(crs, 0, data->getLength());
+
+    data->release();
+
+    if (crs_parser.found_gpio_interrupts) {
+        setProperty("gpioPin", crs_parser.gpio_interrupts.pin_number, 16);
+        setProperty("gpioIRQ", crs_parser.gpio_interrupts.irq_type, 16);
+
+        has_gpio_interrupts = true;
+        gpio_pin = crs_parser.gpio_interrupts.pin_number;
+        gpio_irq = crs_parser.gpio_interrupts.irq_type;
+        IOLog("%s::%s GPIO interrupts retrieved through _DSM method", controller_name, getName());
+        return kIOReturnSuccess;
+    } else {
+        has_gpio_interrupts = false;
+        return kIOReturnNotFound;
     }
 }
 
@@ -110,32 +242,39 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
         has_gpio_interrupts = false;
     }
 
+    data->release();
+
     if (!has_gpio_interrupts) {
         OSArray* interrupt_array = OSDynamicCast(OSArray, acpi_device->getProperty(gIOInterruptSpecifiersKey));
         if (!interrupt_array) {
-            IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts; if your chosen satellite implements polling then %s will run in polling mode.\n", controller_name, getName(), getName());
-            goto exit;
+            IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts.\n", controller_name, getName());
+            goto attempt;
         }
 
         OSData* interrupt_data = OSDynamicCast(OSData, interrupt_array->getObject(0));
 
         if (!interrupt_data) {
-            IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts; if your chosen satellite implements polling then %s will run in polling mode.\n", controller_name, getName(), getName());
-            goto exit;
+            IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts.\n", controller_name, getName());
+            goto attempt;
         }
 
         const UInt16* interrupt_pin = reinterpret_cast<const UInt16*>(interrupt_data->getBytesNoCopy(0, 1));
 
         if (!interrupt_pin) {
-            IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts; if your chosen satellite implements polling then %s will run in polling mode.\n", controller_name, getName(), getName());
-            goto exit;
+            IOLog("%s::%s Warning: Could not find any APIC nor GPIO interrupts.\n", controller_name, getName());
+            goto attempt;
         }
 
-        if (*interrupt_pin > 0x2f)
-            IOLog("%s::%s Warning: Incompatible APIC interrupt pin (0x%x > 0x2f) and no GPIO interrupts found; if your chosen satellite implements polling then %s will run in polling mode.\n", controller_name, getName(), *interrupt_pin, getName());
+        if (*interrupt_pin > 0x2f) {
+            IOLog("%s::%s Warning: Incompatible APIC interrupt pin (0x%x > 0x2f) and no GPIO interrupts found.\n", controller_name, getName(), *interrupt_pin);
+            goto attempt;
+        }
     }
-exit:
-    data->release();
+    return kIOReturnSuccess;
+attempt:
+    IOLog("%s::%s Attempting to get GPIO interrupts from _DSM.\n", controller_name, getName());
+    if (getDeviceResourcesDSM() != kIOReturnSuccess)
+        IOLog("%s::%s Warning: If your chosen satellite implements polling then %s will run in polling mode.\n", controller_name, getName(), getName());
     return kIOReturnSuccess;
 }
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -14,7 +14,6 @@
 #include <IOKit/IOService.h>
 #include <IOKit/acpi/IOACPIPlatformDevice.h>
 #include "../../../Dependencies/VoodooGPIO/VoodooGPIO/VoodooGPIO.hpp"
-#include "../../../Dependencies/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.hpp"
 
 #ifndef EXPORT
 #define EXPORT __attribute__((visibility("default")))
@@ -22,6 +21,7 @@
 
 #define I2C_DSM_TP7G "ef87eb82-f951-46da-84ec-14871ac6f84b"
 #define I2C_DSM_REVISION 1
+#define DSM_SUPPORT_INDEX 0
 #define TP7G_GPIO_INDEX 1
 
 class VoodooI2CControllerDriver;
@@ -193,27 +193,21 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     /* Evaluate _DSM for specific GUID and function index
      * @uuid Human-readable GUID string (big-endian)
      * @index Function index
-     * @result The return data
+     * @result The return is a buffer containing one bit for each function index if Function Index is zero, otherwise could be any data object (See 9.1.1 _DSM (Device Specific Method) in ACPI Specification, Version 6.3)
      *
      * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, otherwise failed when executing *evaluateObject*.
      */
 
     IOReturn evaluateDSM(const char *uuid, UInt32 index, OSObject **result);
 
-    /* Evaluate _DSM for availability of resources like GPIO interrupts.
+    /* Evaluate _DSM for availability of I2C resources like GPIO interrupts.
+     * @index Function index
+     * @result The return could be any data object
      *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if GPIO interrupts were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support GPIO report.
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if GPIO interrupts were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support desired function
      */
 
-    IOReturn getDeviceResourcesDSM();
-
-    /* Instantiates a <VoodooI2CACPICRSParser> object to grab GPIO interrupt properties from _DSM.
-     * @crs_parser The parser for default _CRS
-     *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) and GPIO parse, *kIOReturnNotFound* if GPIO interrupts were unavailable.
-     */
-
-    IOReturn getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
+    IOReturn getDeviceResourcesDSM(UInt32 index, OSObject **result);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -20,6 +20,7 @@
 #endif
 
 #define I2C_DSM_TP7G "ef87eb82-f951-46da-84ec-14871ac6f84b"
+#define I2C_DSM_REVISION 1
 #define TP7G_GPIO_INDEX 1
 
 class VoodooI2CControllerDriver;
@@ -187,6 +188,16 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
      */
 
     IOReturn getDeviceResources();
+
+    /* Evaluate _DSM for specific GUID and function index
+     * @uuid Human-readable GUID string (big-endian)
+     * @index Function index
+     * @result The return data
+     *
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, otherwise failed when executing *evaluateObject*.
+     */
+
+    IOReturn evaluateDSM(const char *uuid, UInt32 index, OSObject **result);
 
     /* Evaluate _DSM for availability of resources like GPIO interrupts.
      *

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -14,6 +14,7 @@
 #include <IOKit/IOService.h>
 #include <IOKit/acpi/IOACPIPlatformDevice.h>
 #include "../../../Dependencies/VoodooGPIO/VoodooGPIO/VoodooGPIO.hpp"
+#include "../../../Dependencies/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.hpp"
 
 #ifndef EXPORT
 #define EXPORT __attribute__((visibility("default")))
@@ -204,10 +205,17 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
      * @index Function index
      * @result The return could be any data object
      *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if GPIO interrupts were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support desired function
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if resources were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support desired function
      */
 
     IOReturn getDeviceResourcesDSM(UInt32 index, OSObject **result);
+
+    /* Instantiates a <VoodooI2CACPICRSParser> object to retrieve GPIO interrupt from _DSM.
+     * @crs_parser The parser for default _CRS
+     *
+     * @return true if GPIO interrupt is available from _DSM
+     */
+    bool getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -213,7 +213,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     /* Instantiates a <VoodooI2CACPICRSParser> object to retrieve GPIO interrupt from _DSM.
      * @crs_parser The parser for default _CRS
      *
-     * @return true if GPIO interrupt is available from _DSM
+     * @return true if GPIO interrupt is parsed from _DSM successfully
      */
     bool getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -20,7 +20,7 @@
 #endif
 
 #define I2C_DSM_TP7G "ef87eb82-f951-46da-84ec-14871ac6f84b"
-#define I2C_DSM_HIDG "3cdff6f7-4267-4555-ad05-b30a3d8938de"
+#define TP7G_GPIO_INDEX 1
 
 class VoodooI2CControllerDriver;
 
@@ -188,27 +188,19 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
 
     IOReturn getDeviceResources();
 
-    /* Evaluate _DSM for availability of GPIO interrupts.
+    /* Evaluate _DSM for availability of resources like GPIO interrupts.
      *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(XDSM*) parse, *kIOReturnNotFound* if GPIO interrupts were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support GPIO.
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if GPIO interrupts were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support GPIO report.
      */
 
     IOReturn getDeviceResourcesDSM();
 
     /* Instantiates a <VoodooI2CACPICRSParser> object to grab GPIO interrupt properties from _DSM.
      *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(XDSM*) and GPIO parse, *kIOReturnNotFound* if GPIO interrupts were unavailable.
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) and GPIO parse, *kIOReturnNotFound* if GPIO interrupts were unavailable.
      */
 
-    IOReturn getDSMGPIOInterrupt();
-
-    /*
-     * Gets the HID descriptor address by evaluating the device's '_DSM' method in the ACPI tables
-     *
-     * @return *kIOReturnSuccess* on sucessfully getting the HID descriptor address, *kIOReturnNotFound* if neither the '_DSM' method nor the '_XDSM' was found, *kIOReturnInvalid* if the address is invalid
-     */
-
-    IOReturn getHIDDescriptorAddress();
+    IOReturn getAlternativeGPIOInterrupt();
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -19,6 +19,9 @@
 #define EXPORT __attribute__((visibility("default")))
 #endif
 
+#define I2C_DSM_TP7G "ef87eb82-f951-46da-84ec-14871ac6f84b"
+#define I2C_DSM_HIDG "3cdff6f7-4267-4555-ad05-b30a3d8938de"
+
 class VoodooI2CControllerDriver;
 
 /* Implements a device nub to which an instance of a device driver may attach. Examples include <VoodooI2CHIDDevice>
@@ -184,6 +187,28 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
      */
 
     IOReturn getDeviceResources();
+
+    /* Evaluate _DSM for availability of GPIO interrupts.
+     *
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(XDSM*) parse, *kIOReturnNotFound* if GPIO interrupts were unavailable, *kIOReturnUnsupportedMode* if _DSM doesn't support GPIO.
+     */
+
+    IOReturn getDeviceResourcesDSM();
+
+    /* Instantiates a <VoodooI2CACPICRSParser> object to grab GPIO interrupt properties from _DSM.
+     *
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(XDSM*) and GPIO parse, *kIOReturnNotFound* if GPIO interrupts were unavailable.
+     */
+
+    IOReturn getDSMGPIOInterrupt();
+
+    /*
+     * Gets the HID descriptor address by evaluating the device's '_DSM' method in the ACPI tables
+     *
+     * @return *kIOReturnSuccess* on sucessfully getting the HID descriptor address, *kIOReturnNotFound* if neither the '_DSM' method nor the '_XDSM' was found, *kIOReturnInvalid* if the address is invalid
+     */
+
+    IOReturn getHIDDescriptorAddress();
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -201,9 +201,17 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     int gpio_irq;
     UInt16 gpio_pin;
     UInt8 i2c_address;
-    bool has_gpio_interrupts;
-    bool use_10bit_addressing;
+    bool has_gpio_interrupts {false};
+    bool has_apic_interrupts {false};
+    bool use_10bit_addressing {false};
     IOWorkLoop* work_loop = nullptr;
+
+    /* Check if a valid interrupt is available less than 0x2f
+     *
+     * @return true if the interrupt can be used
+     */
+
+    bool validateInterrupt();
 
     /* Instantiates a <VoodooI2CACPICRSParser> object to grab I2C slave properties as well as potential GPIO interrupt properties.
      *
@@ -217,6 +225,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
      *
      * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if no GPIO Interrupt were found.
      */
+
     IOReturn getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -201,8 +201,8 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     int gpio_irq;
     UInt16 gpio_pin;
     UInt8 i2c_address;
-    bool has_gpio_interrupts {false};
     bool has_apic_interrupts {false};
+    bool has_gpio_interrupts {false};
     bool use_10bit_addressing {false};
     IOWorkLoop* work_loop = nullptr;
 
@@ -220,13 +220,13 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
 
     IOReturn getDeviceResources();
 
-    /* Instantiates a <VoodooI2CACPICRSParser> object to retrieve GPIO interrupt from _DSM.
+    /* Instantiates a <VoodooI2CACPICRSParser> object to retrieve interrupts from _DSM.
      * @crs_parser The parser for default _CRS
      *
-     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if no GPIO Interrupt were found.
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if no interrupts were found.
      */
 
-    IOReturn getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
+    IOReturn getAlternativeInterrupt(VoodooI2CACPICRSParser* crs_parser);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -14,6 +14,7 @@
 #include <IOKit/IOService.h>
 #include <IOKit/acpi/IOACPIPlatformDevice.h>
 #include "../../../Dependencies/VoodooGPIO/VoodooGPIO/VoodooGPIO.hpp"
+#include "../../../Dependencies/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.hpp"
 
 #ifndef EXPORT
 #define EXPORT __attribute__((visibility("default")))
@@ -207,11 +208,12 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     IOReturn getDeviceResourcesDSM();
 
     /* Instantiates a <VoodooI2CACPICRSParser> object to grab GPIO interrupt properties from _DSM.
+     * @crs_parser The parser for default _CRS
      *
      * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) and GPIO parse, *kIOReturnNotFound* if GPIO interrupts were unavailable.
      */
 
-    IOReturn getAlternativeGPIOInterrupt();
+    IOReturn getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -213,9 +213,9 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     /* Instantiates a <VoodooI2CACPICRSParser> object to retrieve GPIO interrupt from _DSM.
      * @crs_parser The parser for default _CRS
      *
-     * @return true if GPIO interrupt is parsed from _DSM successfully
+     * @return *kIOReturnSuccess* upon a successfull *_DSM*(*XDSM*) parse, *kIOReturnNotFound* if no GPIO Interrupt were found.
      */
-    bool getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
+    IOReturn getAlternativeGPIOInterrupt(VoodooI2CACPICRSParser* crs_parser);
 
     /* Searches the IOService plane to find a <VoodooGPIO> controller object.
      */


### PR DESCRIPTION
For ACPI code of some I2C controller, GPIO interrupt are also available from `_DSM` with an undocumented GUID `ef87eb82-f951-46da-84ec-14871ac6f84b`. When both APIC and GPIO are unavailable, check `_DSM` for GPIO.

Sample ASL code:
```
Method (TP7D, 6, Serialized)
{
    If ((Arg0 == TP7G))
    {
        If ((Arg2 == Zero))
        {
            If ((Arg1 == One))
            {
                Return (Buffer (One)
                {
                     0x03                                           
                })
            }
        }

        If ((Arg2 == One))
        {
            Return (ConcatenateResTemplate (Arg4, Arg5))
        }
    }

    Return (Buffer (One)
    {
         0x00                                           
    })
}

Method (_DSM, 4, Serialized)  // _DSM: Device-Specific Method
{
    If ((Arg0 == HIDG))
    {
        Return (HIDD (Arg0, Arg1, Arg2, Arg3, HID2))
    }

    If ((Arg0 == TP7G))
    {
        Return (TP7D (Arg0, Arg1, Arg2, Arg3, SBFB, SBFG))
    }

    Return (Buffer (One)
    {
         0x00                                           
    })
}

```