### PR TITLE
Follow up of requested changes in #365; potential optimization of APIC / GPIO interrupt validation

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -125,16 +125,11 @@ IOReturn VoodooI2CDeviceNub::getDeviceResourcesDSM(UInt32 index, OSObject **resu
 
 IOReturn VoodooI2CDeviceNub::getAlternativeInterrupt(VoodooI2CACPICRSParser* crs_parser) {
     OSObject *result = nullptr;
-    if (getDeviceResourcesDSM(TP7G_GPIO_INDEX, &result) != kIOReturnSuccess) {
-        IOLog("%s::%s failed to retrieve interrupts from _DSM or XDSM method\n", controller_name, getName());
-        result->release();
-        return kIOReturnNotFound;
-    }
-
-    OSData *data = OSDynamicCast(OSData, result);
-    if (!data) {
-        IOLog("%s::%s Could not get valid return for interrupts from _DSM or XDSM method\n", controller_name, getName());
-        result->release();
+    OSData *data = nullptr;
+    if (getDeviceResourcesDSM(TP7G_GPIO_INDEX, &result) != kIOReturnSuccess ||
+        !(data = OSDynamicCast(OSData, result))) {
+        IOLog("%s::%s Could not retrieve interrupts from _DSM or XDSM method\n", controller_name, getName());
+        OSSafeReleaseNULL(result);
         return kIOReturnNotFound;
     }
 
@@ -169,13 +164,12 @@ bool VoodooI2CDeviceNub::validateInterrupt() {
 }
 
 IOReturn VoodooI2CDeviceNub::getDeviceResources() {
-    OSObject *result = NULL;
-    acpi_device->evaluateObject("_CRS", &result);
-
-    OSData *data = OSDynamicCast(OSData, result);
-    if (!data) {
+    OSObject *result = nullptr;
+    OSData *data = nullptr;
+    if (acpi_device->evaluateObject("_CRS", &result) != kIOReturnSuccess ||
+        !(data = OSDynamicCast(OSData, result))) {
         IOLog("%s::%s Could not find or evaluate _CRS method\n", controller_name, getName());
-        result->release();
+        OSSafeReleaseNULL(result);
         return kIOReturnNotFound;
     }
 


### PR DESCRIPTION
https://github.com/VoodooI2C/VoodooI2C/pull/365#pullrequestreview-501553472

@Goshin @ben9923 @kprinssu 

Thank you for your review on the previous PR.

Current checklist for device resource is:
1. evaluate `_CRS`
This method must exist and allow custom modification (`SBFI` -> `SBFG` etc)
I2C declaration is obtained here
2. check for GPIO interrupt
It's either a native one or modified by user (who take responsibility for valid pin config)
No additional check here, skip next step
3. If APIC interrupt pin is not valid, then evaluate `_DSM` for alternative GPIO
Corresponding `_DSM` GUID may not exist in some early models.
4. If GPIO interrupt is selected, get pin and irq. Otherwise, APIC interrupt will just work or try polling.

If APIC is to be prioritized, APIC will be verified first and other information in `_CRS` will be ignored. I suppose user won't have choice to override that?