### PR TITLE
Evaluate XDSM first for easy customization and document updates

### DIFF
--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -75,7 +75,7 @@ You can think of polling mode as the "safe boot" mode of VoodooI2C. As such it i
 
 However, it is highly recommended that once your system is up and running, you should apply all the GPIO patches (except Haswell and Broadwell users) to ensure optimal performance. If you find that you cannot get your trackpad to work in interrupts mode or that interrupts mode leads to high CPU usage then it is likely you have a system with a buggy implementation of GPIO. In this case you will have to switch back to polling mode. In any case, you should still go through the troubleshooting process as outlined on the <Troubleshooting> page to make sure that you have not made a mistake.
 
-Staring from 2.5.3, VooodooI2C will try to extract GPIO pin information on compatible machine if APIC interrupt is unavailable. In case it's not working, you can force polling mode by adding `-vi2c-no-alt-interrupts` to `boot-arg` or adding `force-polling` to specific I2C controller with `Devices`-`Properties` section for Clover or `DeviceProperties` section for OpenCore.
+Staring from 2.5.3, VooodooI2C will try to extract GPIO pin information on compatible machine if APIC interrupt is unavailable. In case it's not working, you can force polling mode by adding `-vi2c-no-alt-interrupts` to `boot-arg` or adding `force-polling` to specific I2C controller in `Devices`-`Properties` section for Clover or `DeviceProperties` section for OpenCore.
 
 ### Windows Patches
 

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -32,16 +32,18 @@ If the number is not **at least** 4 then your system is not suitable for VoodooI
 	1. 'INT33C2' and 'INT33C3' - Haswell era
 	2. 'INT3432' and 'INT3433' - Broadwell era
 	3. 'pci8086,9d60', 'pci8086,9d61', 'pci8086,9d62' and 'pci8086,9d63' - Skylake era
-	4. 'pci8086,a160' and 'pci8086,a161' - Kaby Lake era
-	5. 'pci8086,9de8' and 'pci8086,9de9' - Cannon Lake/Whiskey Lake era
+	4. 'pci8086,a160', 'pci8086,a161' and 'pci8086,a162' - Kaby Lake era
+	5. 'pci8086,9de8', 'pci8086,9de9', 'pci8086,9dea' and 'pci8086,9deb' - Cannon Lake/Whiskey Lake era
 	6. 'pci8086,a368', 'pci8086,a369', 'pci8086,a36a' and 'pci8086,a36b' - Coffee Lake era
-	7. 'pci8086,2e8' and 'pci8086,2e9' - Comet Lake era
+	7. 'pci8086,2e8', 'pci8086,2e9', 'pci8086,2ea', 'pci8086,2eb',
+	   'pci8086,6e8', 'pci8086,6e9', 'pci8086,6ea' and 'pci8086,6eb' - Comet Lake era
+	8. 'pci8086,34e8', 'pci8086,34e9', 'pci8086,34ea' and 'pci8086,34eb' - Ice Lake era
 
 4. Your machine should have at least one supported I2C device. For the vast majority of users, this will be an I2C-HID device. Examples of I2C-HID devices include Precision touchpads, touchscreens and sensor hubs.
 
 5. Your hackintosh is running at least 10.10 Yosemite. VoodooI2C may work on earlier versions of macOS but we do not provide support for machines that are not running at least 10.10.
 
-6. Your hackintosh is using the Clover bootloader. Your mileage may vary with other bootloaders but we do not provide support for machines that do not use the Clover bootloader.
+6. Your hackintosh is using the Clover bootloader or the OpenCore bootloader. Your mileage may vary with other bootloaders but we do not provide support for machines that do not use the Clover bootloader.
 
 If you meet all 5 of these requirements then you may proceed with the next section of this installation guide.
 
@@ -72,6 +74,8 @@ The exact definitions of polling and interrupts are outside the scope of this gu
 You can think of polling mode as the "safe boot" mode of VoodooI2C. As such it is a suitable mode for use during the installation of macOS. Polling mode is also suitable for people who have Skylake or newer machines with buggy GPIO implementation (such as various ASUS laptops). If you wish to run VoodooI2C in polling mode, you do not need to apply any of the GPIO patches below but you must visit the <Polling Mode> page for further instructions.
 
 However, it is highly recommended that once your system is up and running, you should apply all the GPIO patches (except Haswell and Broadwell users) to ensure optimal performance. If you find that you cannot get your trackpad to work in interrupts mode or that interrupts mode leads to high CPU usage then it is likely you have a system with a buggy implementation of GPIO. In this case you will have to switch back to polling mode. In any case, you should still go through the troubleshooting process as outlined on the <Troubleshooting> page to make sure that you have not made a mistake.
+
+Staring from 2.5.3, VooodooI2C will try to extract GPIO pin information on compatible machine if APIC interrupt is unavailable. In case it's not working, you can force polling mode by adding `-vi2c-no-alt-interrupts` to `boot-arg` or adding `force-polling` to specific I2C controller with `Devices`-`Properties` section for Clover or `DeviceProperties` section for OpenCore.
 
 ### Windows Patches
 

--- a/Documentation/Installation.md
+++ b/Documentation/Installation.md
@@ -32,7 +32,7 @@ If the number is not **at least** 4 then your system is not suitable for VoodooI
 	1. 'INT33C2' and 'INT33C3' - Haswell era
 	2. 'INT3432' and 'INT3433' - Broadwell era
 	3. 'pci8086,9d60', 'pci8086,9d61', 'pci8086,9d62' and 'pci8086,9d63' - Skylake era
-	4. 'pci8086,a160', 'pci8086,a161' and 'pci8086,a162' - Kaby Lake era
+	4. 'pci8086,a160', 'pci8086,a161', 'pci8086,a162' and 'pci8086,a163' - Kaby Lake era
 	5. 'pci8086,9de8', 'pci8086,9de9', 'pci8086,9dea' and 'pci8086,9deb' - Cannon Lake/Whiskey Lake era
 	6. 'pci8086,a368', 'pci8086,a369', 'pci8086,a36a' and 'pci8086,a36b' - Coffee Lake era
 	7. 'pci8086,2e8', 'pci8086,2e9', 'pci8086,2ea', 'pci8086,2eb',

--- a/Documentation/SSDT-I2CD.dsl
+++ b/Documentation/SSDT-I2CD.dsl
@@ -1,7 +1,7 @@
 /*
  * Table for debuging common I2C constants.
  *
- * Please note you might need a remove _INI hacks temporary to reveal
+ * Please note you might need to remove _INI hacks temporary for
  * original value.
  */
 DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
@@ -16,6 +16,8 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
     External (SMD2, FieldUnitObj)
     External (SMD3, FieldUnitObj)
     // I2C Interrupt mode
+    External (GPDI, FieldUnitObj)
+    External (GPLI, FieldUnitObj)
     External (SDM0, FieldUnitObj)
     External (SDM1, FieldUnitObj)
     // I2C Device type
@@ -26,14 +28,14 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
     {
         Device (I2CD)
         {
-            Name (_HID, EisaId ("PNP0C02"))  // _HID: Hardware ID
+            Name (_HID, EisaId ("PNP0C02"))
             Name (_STA, 0x0F)  // _STA: Status
 
             If (CondRefOf (\GPEN))
             {
                 Device (GPEN)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\GPEN)
                     }
@@ -44,7 +46,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SBRG)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SBRG)
                     }
@@ -55,7 +57,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SMD0)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SMD0)
                     }
@@ -66,7 +68,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SMD1)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SMD1)
                     }
@@ -77,7 +79,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SMD2)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SMD2)
                     }
@@ -88,9 +90,31 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SMD3)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SMD3)
+                    }
+                }
+            }
+
+            If (CondRefOf (\GPDI))
+            {
+                Device (GPDI)
+                {
+                    Method (_ADR, 0, Serialized)
+                    {
+                        Return (\GPDI)
+                    }
+                }
+            }
+
+            If (CondRefOf (\GPLI))
+            {
+                Device (GPLI)
+                {
+                    Method (_ADR, 0, Serialized)
+                    {
+                        Return (\GPLI)
                     }
                 }
             }
@@ -99,7 +123,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SDM0)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SDM0)
                     }
@@ -110,7 +134,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SDM1)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SDM1)
                     }
@@ -121,7 +145,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SDS0)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SDS0)
                     }
@@ -132,7 +156,7 @@ DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
             {
                 Device (SDS1)
                 {
-                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    Method (_ADR, 0, Serialized)
                     {
                         Return (\SDS1)
                     }

--- a/Documentation/SSDT-I2CD.dsl
+++ b/Documentation/SSDT-I2CD.dsl
@@ -1,0 +1,144 @@
+/*
+ * Table for debuging common I2C constants.
+ *
+ * Please note you might need a remove _INI hacks temporary to reveal
+ * original value.
+ */
+DefinitionBlock ("", "SSDT", 2, "hack", "I2CD", 0x00000000)
+{
+    // Enable GPIO
+    External (GPEN, FieldUnitObj)
+    // Base address for GPIO config calculation
+    External (SBRG, FieldUnitObj)
+    // I2C Controller mode
+    External (SMD0, FieldUnitObj)
+    External (SMD1, FieldUnitObj)
+    External (SMD2, FieldUnitObj)
+    External (SMD3, FieldUnitObj)
+    // I2C Interrupt mode
+    External (SDM0, FieldUnitObj)
+    External (SDM1, FieldUnitObj)
+    // I2C Device type
+    External (SDS0, FieldUnitObj)
+    External (SDS1, FieldUnitObj)
+
+    Scope (\_SB)
+    {
+        Device (I2CD)
+        {
+            Name (_HID, EisaId ("PNP0C02"))  // _HID: Hardware ID
+            Name (_STA, 0x0F)  // _STA: Status
+
+            If (CondRefOf (\GPEN))
+            {
+                Device (GPEN)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\GPEN)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SBRG))
+            {
+                Device (SBRG)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SBRG)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SMD0))
+            {
+                Device (SMD0)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SMD0)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SMD1))
+            {
+                Device (SMD1)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SMD1)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SMD2))
+            {
+                Device (SMD2)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SMD2)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SMD3))
+            {
+                Device (SMD3)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SMD3)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SDM0))
+            {
+                Device (SDM0)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SDM0)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SDM1))
+            {
+                Device (SDM1)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SDM1)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SDS0))
+            {
+                Device (SDS0)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SDS0)
+                    }
+                }
+            }
+
+            If (CondRefOf (\SDS1))
+            {
+                Device (SDS1)
+                {
+                    Method (_ADR, 0, Serialized)  // _ADR: Address
+                    {
+                        Return (\SDS1)
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -19,7 +19,7 @@ Please provide all requested IORegs using IORegExplorer v2.1 which can be obtain
 
 If after following the installation guide you get no or buggy input you will need to prepare an archive containing the following:
 
-1. A copy of your IOReg with VoodooI2C installed.
+1. A copy of your IOReg with VoodooI2C installed (and [SSDT-I2CD](https://github.com/VoodooI2C/VoodooI2C/blob/master/Documentation/SSDT-I2CD.dsl) injected for dumping constants).
 2. A copy of your original and patched DSDT.
 3. If you are on 10.11, a copy of your `system.log` from the Console app. If you are on 10.12+, a copy of the log as outlined on the <Common Errors> page.
 4. A text file containing the following information:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following Intel I2C controllers are fully supported:
 4. `pci8086,a160`, `pci8086,a161`, `pci8086,a162` and `pci8086,a163` - Kaby Lake era
 5. `pci8086,9de8`, `pci8086,9de9`, `pci8086,9dea` and `pci8086,9deb` - Cannon Lake/Whiskey Lake era
 6. `pci8086,a368`, `pci8086,a369`, `pci8086,a36a` and `pci8086,a36b` - Coffee Lake era
-7. `pci8086,2e8`,  `pci8086,2e9`, `pci8086,2ea`,  `pci8086,2eb`, `pci8086,6e8` and `pci8086,6e9`, `pci8086,6ea` and `pci8086,6eb`- Comet Lake era
+7. `pci8086,2e8`, `pci8086,2e9`, `pci8086,2ea`, `pci8086,2eb`, `pci8086,6e8`, `pci8086,6e9`, `pci8086,6ea` and `pci8086,6eb`- Comet Lake era
 8. `pci8086,34e8`, `pci8086,34e9`, `pci8086,34ea` and `pci8086,34eb` - Ice Lake era
 
 The following device classes are fully supported:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following Intel I2C controllers are fully supported:
 1. `INT33C2` and `INT33C3` - Haswell era
 2. `INT3432` and `INT3433` - Broadwell era
 3. `pci8086,9d60`, `pci8086,9d61`, `pci8086,9d62` and `pci8086,9d63` - Skylake era
-4. `pci8086,a160`, `pci8086,a161` and `pci8086,a162` - Kaby Lake era
+4. `pci8086,a160`, `pci8086,a161`, `pci8086,a162` and `pci8086,a163` - Kaby Lake era
 5. `pci8086,9de8`, `pci8086,9de9`, `pci8086,9dea` and `pci8086,9deb` - Cannon Lake/Whiskey Lake era
 6. `pci8086,a368`, `pci8086,a369`, `pci8086,a36a` and `pci8086,a36b` - Coffee Lake era
 7. `pci8086,2e8`,  `pci8086,2e9`, `pci8086,2ea`,  `pci8086,2eb`, `pci8086,6e8` and `pci8086,6e9`, `pci8086,6ea` and `pci8086,6eb`- Comet Lake era

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ The following Intel I2C controllers are fully supported:
 1. `INT33C2` and `INT33C3` - Haswell era
 2. `INT3432` and `INT3433` - Broadwell era
 3. `pci8086,9d60`, `pci8086,9d61`, `pci8086,9d62` and `pci8086,9d63` - Skylake era
-4. `pci8086,a160` and `pci8086,a161` - Kaby Lake era
-5. `pci8086,9de8` and `pci8086,9de9` - Cannon Lake/Whiskey Lake era
+4. `pci8086,a160`, `pci8086,a161` and `pci8086,a162` - Kaby Lake era
+5. `pci8086,9de8`, `pci8086,9de9`, `pci8086,9dea` and `pci8086,9deb` - Cannon Lake/Whiskey Lake era
 6. `pci8086,a368`, `pci8086,a369`, `pci8086,a36a` and `pci8086,a36b` - Coffee Lake era
-7. `pci8086,2e8`,  `pci8086,2e9`, `pci8086,6e8` and `pci8086,6e9`- Comet Lake era
+7. `pci8086,2e8`,  `pci8086,2e9`, `pci8086,2ea`,  `pci8086,2eb`, `pci8086,6e8` and `pci8086,6e9`, `pci8086,6ea` and `pci8086,6eb`- Comet Lake era
+8. `pci8086,34e8`, `pci8086,34e9`, `pci8086,34ea` and `pci8086,34eb` - Ice Lake era
 
 The following device classes are fully supported:
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -91,6 +91,8 @@ IOReturn VoodooI2CDeviceNub::evaluateDSM(const char *uuid, UInt32 index, OSObjec
     ret = acpi_device->evaluateObject("XDSM", result, params, 4);
     if (ret != kIOReturnSuccess)
         ret = acpi_device->evaluateObject("_DSM", result, params, 4);
+    else
+        IOLog("%s::%s Warning: support for XDSM method is deprecated and will be removed in future release, please remove related rename.\n", controller_name, getName());
 
     params[0]->release();
     params[1]->release();

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -88,9 +88,9 @@ IOReturn VoodooI2CDeviceNub::evaluateDSM(const char *uuid, UInt32 index, OSObjec
         OSArray::withCapacity(1),
     };
 
-    ret = acpi_device->evaluateObject("_DSM", result, params, 4);
+    ret = acpi_device->evaluateObject("XDSM", result, params, 4);
     if (ret != kIOReturnSuccess)
-        ret = acpi_device->evaluateObject("XDSM", result, params, 4);
+        ret = acpi_device->evaluateObject("_DSM", result, params, 4);
 
     params[0]->release();
     params[1]->release();

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -89,10 +89,11 @@ IOReturn VoodooI2CDeviceNub::evaluateDSM(const char *uuid, UInt32 index, OSObjec
     };
 
     ret = acpi_device->evaluateObject("XDSM", result, params, 4);
-    if (ret != kIOReturnSuccess)
+    if (ret != kIOReturnSuccess) {
         ret = acpi_device->evaluateObject("_DSM", result, params, 4);
-    else
-        IOLog("%s::%s Warning: support for XDSM method is deprecated and will be removed in future release, please remove related rename.\n", controller_name, getName());
+    } else {
+        IOLog("%s::%s Warning: support for XDSM method is deprecated and will be removed in a future release, please remove related rename.\n", controller_name, getName());
+    }
 
     params[0]->release();
     params[1]->release();


### PR DESCRIPTION
When drafting prior PR, I have considered if `XDSM` support could be dropped since the approach is already deprecated. However, I found it could be difficult to edit `_DSM` if one want to force polling mode instead of GPIO when updating the docs. I also wonder if GPIO pin would need to be updated under rare circumstances. Then insert `XDSM` could be an easy implementation for customization.