### PR TITLE
Option to opt-out from _DSM/XDSM interrupts

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -196,7 +196,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     uint32_t checkForAltInterrupts;
     if (crs_parser.found_gpio_interrupts ||
         (!validateInterrupt() && getAlternativeInterrupt(&crs_parser) == kIOReturnSuccess &&
-         !PE_parse_boot_argn("-vi2c-no-alt-interrupts", &checkForAltInterrupts, sizeof(checkForAltInterrupts)))) {
+         !PE_parse_boot_argn("-vi2c-force-polling", &checkForAltInterrupts, sizeof(checkForAltInterrupts)))) {
         setProperty("gpioPin", crs_parser.gpio_interrupts.pin_number, 16);
         setProperty("gpioIRQ", crs_parser.gpio_interrupts.irq_type, 16);
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -193,8 +193,10 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
         return kIOReturnNotFound;
     }
 
+    uint32_t checkForAltInterrupts;
     if (crs_parser.found_gpio_interrupts ||
-        (!validateInterrupt() && getAlternativeInterrupt(&crs_parser) == kIOReturnSuccess)) {
+        (!validateInterrupt() && getAlternativeInterrupt(&crs_parser) == kIOReturnSuccess &&
+         !PE_parse_boot_argn("-vi2c-no-alt-interrupts", &checkForAltInterrupts, sizeof(checkForAltInterrupts)))) {
         setProperty("gpioPin", crs_parser.gpio_interrupts.pin_number, 16);
         setProperty("gpioIRQ", crs_parser.gpio_interrupts.irq_type, 16);
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -194,15 +194,11 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     }
 
     IOPCIDevice *pci_device { nullptr };
-    bool force_polling { false };
 
     pci_device = controller->nub->controller->physical_device.pci_device;
 
-    if (checkKernelArg("-vi2c-force-polling")) {
-        force_polling = true;
-    } else if (pci_device) {
-        force_polling = pci_device->getProperty("force-polling") != nullptr;
-    }
+    bool force_polling = checkKernelArg("-vi2c-force-polling");
+    force_polling = force_polling || ((pci_device != nullptr) && (pci_device->getProperty("force-polling") != nullptr));
 
     if (!force_polling) {
         if (crs_parser.found_gpio_interrupts ||

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -213,7 +213,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     uint32_t forcePolling;
     if (checkKernelArg("-vi2c-force-polling")) {
         use_alt_interrupts = false;
-    } else if (readProperty(pci_controller_entry, "force-polling", forcePolling)) {
+    } else if (readProperty(pci_controller_entry, "force-polling", &forcePolling)) {
         use_alt_interrupts = forcePolling != 1;
     }
     

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -31,11 +31,11 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
         IOLog("%s::%s Could not get controller\n", controller_name, child->getName());
         return false;
     }
-    
+
     auto matchingDict = IOService::serviceMatching("VoodooI2CPCIController");
     auto service = IOService::waitForMatchingService(matchingDict, 100000000);
     matchingDict->release();
-    
+
     if (service != nullptr) {
         if (service->getParentEntry(gIOServicePlane) != nullptr) {
             pci_controller_entry = service->getParentEntry(gIOServicePlane);
@@ -208,7 +208,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
         IOLog("%s::%s Could not find an I2C Serial Bus declaration\n", controller_name, getName());
         return kIOReturnNotFound;
     }
-    
+
     // Check if user wants to disable alt-interrupts
     uint32_t forcePolling;
     if (checkKernelArg("-vi2c-force-polling")) {
@@ -216,7 +216,7 @@ IOReturn VoodooI2CDeviceNub::getDeviceResources() {
     } else if (readProperty(pci_controller_entry, "force-polling", &forcePolling)) {
         use_alt_interrupts = forcePolling != 1;
     }
-    
+
     if (crs_parser.found_gpio_interrupts ||
         (!validateInterrupt() && getAlternativeInterrupt(&crs_parser) == kIOReturnSuccess &&
          use_alt_interrupts)) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -205,7 +205,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     bool has_apic_interrupts {false};
     bool has_gpio_interrupts {false};
     bool use_10bit_addressing {false};
-    bool force_polling { true };
+    bool force_polling { false };
     IOPCIDevice *pci_device { nullptr };
     IOWorkLoop* work_loop = nullptr;
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -298,12 +298,12 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
      * @return true if read successful else false
      */
     template <typename T>
-    inline bool readProperty(const IORegistryEntry *entry, const char *name, T &value) {
+    inline bool readProperty(const IORegistryEntry *entry, const char *name, T *value) {
         auto obj = entry->getProperty(name);
         if (obj) {
             auto data = OSDynamicCast(OSData, obj);
             if (data && data->getLength() == sizeof(T)) {
-                value = *static_cast<const T*>(data->getBytesNoCopy());
+                *value = *static_cast<const T*>(data->getBytesNoCopy());
                 return true;
             }
         }

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -204,7 +204,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     bool has_apic_interrupts {false};
     bool has_gpio_interrupts {false};
     bool use_10bit_addressing {false};
-    bool use_alt_interrupts { false };
+    bool use_alt_interrupts = true;
     IORegistryEntry *pci_controller_entry { nullptr };
     IOWorkLoop* work_loop = nullptr;
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -277,7 +277,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
      */
 
     IOReturn writeReadI2CGated(UInt8* write_buffer, UInt16* write_length, UInt8* read_buffer, UInt16* read_length);
-    
+
     /* Check if a boot-arg is present
      *
      * @arg boot-arg property name
@@ -288,7 +288,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
         int val[16];
         return PE_parse_boot_argn(arg, &val, sizeof((val)));
     }
-    
+
     /* Reads a device property from an IORegistryEntry instance
      *
      * @entry IORegistryEntry instance to read from
@@ -307,7 +307,7 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
                 return true;
             }
         }
-        
+
         return false;
     }
 };

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -205,8 +205,6 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     bool has_apic_interrupts {false};
     bool has_gpio_interrupts {false};
     bool use_10bit_addressing {false};
-    bool force_polling { false };
-    IOPCIDevice *pci_device { nullptr };
     IOWorkLoop* work_loop = nullptr;
 
     /* Check if a valid interrupt is available less than 0x2f

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.hpp
@@ -15,6 +15,7 @@
 #include <IOKit/acpi/IOACPIPlatformDevice.h>
 #include "../../../Dependencies/VoodooGPIO/VoodooGPIO/VoodooGPIO.hpp"
 #include "../../../Dependencies/VoodooI2CACPICRSParser/VoodooI2CACPICRSParser.hpp"
+#include "../VoodooI2CController/VoodooI2CController.hpp"
 
 #ifndef EXPORT
 #define EXPORT __attribute__((visibility("default")))
@@ -204,8 +205,8 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     bool has_apic_interrupts {false};
     bool has_gpio_interrupts {false};
     bool use_10bit_addressing {false};
-    bool use_alt_interrupts = true;
-    IORegistryEntry *pci_controller_entry { nullptr };
+    bool force_polling { true };
+    IOPCIDevice *pci_device { nullptr };
     IOWorkLoop* work_loop = nullptr;
 
     /* Check if a valid interrupt is available less than 0x2f
@@ -287,28 +288,6 @@ class EXPORT VoodooI2CDeviceNub : public IOService {
     inline bool checkKernelArg(const char *arg) {
         int val[16];
         return PE_parse_boot_argn(arg, &val, sizeof((val)));
-    }
-
-    /* Reads a device property from an IORegistryEntry instance
-     *
-     * @entry IORegistryEntry instance to read from
-     * @name Property name
-     * @value Read value
-     *
-     * @return true if read successful else false
-     */
-    template <typename T>
-    inline bool readProperty(const IORegistryEntry *entry, const char *name, T *value) {
-        auto obj = entry->getProperty(name);
-        if (obj) {
-            auto data = OSDynamicCast(OSData, obj);
-            if (data && data->getLength() == sizeof(T)) {
-                *value = *static_cast<const T*>(data->getBytesNoCopy());
-                return true;
-            }
-        }
-
-        return false;
     }
 };
 


### PR DESCRIPTION
First off, kudos to @zhen-zen for #365 (interesting find). 

However this feature breaks polling mode on select machines wherein the OEM GPIO implementation is buggy, like on most of the Asus laptops.

This PR adds a boot-arg (`-vi2c-no-alt-interrupts`) to opt out from the alternative interrupts.

Regards