### PR TITLE
Validate whether MatchedName exists

### DIFF
--- a/Dependencies/helpers.cpp
+++ b/Dependencies/helpers.cpp
@@ -11,7 +11,7 @@
 const char* getMatchedName(IOService* provider) {
     OSData *data;
     data = OSDynamicCast(OSData, provider->getProperty("name"));
-    return (const char *)(data->getBytesNoCopy());
+    return (data ? (const char *)(data->getBytesNoCopy()) : "(null)");
 }
 
 UInt16 abs(SInt16 x) {

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -240,8 +240,6 @@ IOReturn VoodooI2CControllerDriver::publishNubs() {
     IOService* child;
     OSIterator* children = nub->controller->physical_device.acpi_device->getChildIterator(gIOACPIPlane);
 
-    OSIterator* children = nub->controller->physical_device.acpi_device->getChildIterator(gIOACPIPlane);
-
     if (!children)
         return kIOReturnNoResources;
 

--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -238,44 +238,36 @@ IOReturn VoodooI2CControllerDriver::publishNubs() {
     IOLog("%s::%s Publishing device nubs\n", getName(), bus_device.name);
 
     IOService* child;
-    IORegistryIterator* children = IORegistryIterator::iterateOver(nub->controller->physical_device.acpi_device, gIOACPIPlane);
+    OSIterator* children = nub->controller->physical_device.acpi_device->getChildIterator(gIOACPIPlane);
 
     if (children) {
-        OSOrderedSet* set = children->iterateAll();
-        if (set) {
-            OSIterator *iterator = OSCollectionIterator::withCollection(set);
-            if (iterator) {
-                while ((child = reinterpret_cast<IOService*>(iterator->getNextObject()))) {
-                    IOLog("%s::%s Found I2C device: %s\n", getName(), bus_device.name, getMatchedName(child));
+        while ((child = reinterpret_cast<IOService*>(children->getNextObject()))) {
+            IOLog("%s::%s Found I2C device: %s\n", getName(), bus_device.name, getMatchedName(child));
 
-                    VoodooI2CDeviceNub* device_nub = OSTypeAlloc(VoodooI2CDeviceNub);
+            VoodooI2CDeviceNub* device_nub = OSTypeAlloc(VoodooI2CDeviceNub);
 
-                    OSDictionary* child_properties = child->dictionaryWithProperties();
-                    bool nub_initialized = true;
-                    if (!device_nub ||
-                        !device_nub->init(child_properties) ||
-                        !device_nub->attach(this, child)) {
-                        nub_initialized = false;
-                    } else if (!device_nub->start(this)) {
-                        device_nub->detach(this);
-                        nub_initialized = false;
-                    }
-
-                    OSSafeReleaseNULL(child_properties);
-
-                    if (!nub_initialized) {
-                        IOLog("%s::%s Could not initialise nub for %s\n", getName(), bus_device.name, getMatchedName(child));
-                        OSSafeReleaseNULL(device_nub);
-
-                        continue;
-                    }
-
-                    device_nubs->setObject(device_nub);
-                    device_nub->release();
-                }
-                iterator->release();
+            OSDictionary* child_properties = child->dictionaryWithProperties();
+            bool nub_initialized = true;
+            if (!device_nub ||
+                !device_nub->init(child_properties) ||
+                !device_nub->attach(this, child)) {
+                nub_initialized = false;
+            } else if (!device_nub->start(this)) {
+                device_nub->detach(this);
+                nub_initialized = false;
             }
-            set->release();
+
+            OSSafeReleaseNULL(child_properties);
+
+            if (!nub_initialized) {
+                IOLog("%s::%s Could not initialise nub for %s\n", getName(), bus_device.name, getMatchedName(child));
+                OSSafeReleaseNULL(device_nub);
+
+                continue;
+            }
+
+            device_nubs->setObject(device_nub);
+            device_nub->release();
         }
         children->release();
     }


### PR DESCRIPTION
Fix #405

The culprit is a nested device `_SB.PCI0.I2C0.UCMX.POR0`, which only contains `_ADR`, `_PLD` and `_UPC`. Here `getMatchedName` failed to acquire `name` at its upper layer.