### PR TITLE
Use Python 3 cldoc/cpplint, update to Xcode 11.7 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
     macos:
-      xcode: 11.4.0
+      xcode: 11.7.0
     steps:
       # Machine Setup
       - checkout
@@ -24,9 +24,8 @@ jobs:
           name: "Download the MacKernelSDK"
           command: git clone https://github.com/acidanthera/MacKernelSDK
       - run: src=$(/usr/bin/curl -Lfs https://raw.githubusercontent.com/acidanthera/VoodooInput/master/VoodooInput/Scripts/bootstrap.sh) && eval "$src" && mv VoodooInput Dependencies
-      - run: pip install cpplint
-      - run: pip install git+https://github.com/alexandred/cldoc.git
-      - run: echo 'export PATH=~/Library/Python/2.7/bin:$PATH' >> ~/.bashrc
+      - run: pip3 install cpplint
+      - run: pip3 install git+https://github.com/VoodooI2C/cldoc.git
       - run: git submodule init && git submodule update
       - run: xcodebuild -workspace "VoodooI2C.xcworkspace" -scheme "VoodooI2C" -derivedDataPath build clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
@@ -50,7 +49,7 @@ jobs:
 
   deploy:
     macos:
-      xcode: 11.4.0
+      xcode: 11.7.0
     steps:
       # Machine Setup
       - checkout

--- a/Documentation/Build Environment.md
+++ b/Documentation/Build Environment.md
@@ -48,7 +48,7 @@ sudo pip install cpplint
 
 In order to streamline user experience, we use (a modified version of) `cldoc` to automatically generate documentation on two levels. `cldoc` will forst compile all the Markdown files in the `Documentation` directory. It will then crawl the project repository and compile documentation for each documented function, class, variable etc. These files are packaged together during continuous integration and are uploaded to the [documentation site](https://voodooi2c.github.io) that you are currently on. We will further discuss documentation later on.
 
-To install `cldoc`, first clone the custom version of `cldoc` from [this repo](https://github.com/alexandred/cldoc) then follow the "Installing from source" instructions found [here](http://jessevdk.github.io/cldoc/gettingstarted.html).
+To install `cldoc`, first clone the custom version of `cldoc` from [this repo](https://github.com/VoodooI2C/cldoc) then follow the "Installing from source" instructions found [here](http://jessevdk.github.io/cldoc/gettingstarted.html).
 
 ## Building, loading, and installing VoodooI2C
 


### PR DESCRIPTION
After package dependency changes resulted from developers not caring about Python 2.7 anymore, let's just install our packages with Python 3.
Also bumped Xcode image version to latest 11.x release.

cldoc fork was moved into the VoodooI2C organization. I've reset the base to upstream code, then pushed minor Python 3 compatibility fixes (Apparently upstream is more compatible with Python 3 than latest PyPI release, yet broken).
Old source we've used so far is kept in the [`old-version` branch](https://github.com/VoodooI2C/cldoc/tree/old-version).