### PR TITLE
Add support for Surface Pro 5/2017 Keyboard/Trackpad

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/VoodooI2C/VoodooGPIO.git
 [submodule "VoodooI2C Satellites/VoodooI2CHID"]
 	path = VoodooI2C Satellites/VoodooI2CHID
-	url = https://github.com/VoodooI2C/VoodooI2CHID.git
+	url = https://github.com/MrHomebrew/VoodooI2CHID.git
 [submodule "VoodooI2C Satellites/VoodooI2CELAN"]
 	path = VoodooI2C Satellites/VoodooI2CELAN
 	url = https://github.com/VoodooI2C/VoodooI2CELAN.git


### PR DESCRIPTION
This should help add support for Surface Pro 5/2017 to allow Keyboard/Trackpad support with Voodooi2c/VoodooHID.