### PR TITLE
Remove overriding bus timing defaults

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp
@@ -466,11 +466,6 @@ bool VoodooI2CControllerDriver::start(IOService* provider) {
 
     if (getBusConfig() != kIOReturnSuccess) {
         IOLog("%s::%s Warning: Error getting bus config, using defaults where necessary\n", getName(), bus_device.name);
-        bus_device.acpi_config.ss_hcnt = 0x01b0;
-        bus_device.acpi_config.fs_hcnt = 0x48;
-        bus_device.acpi_config.ss_lcnt = 0x01fb;
-        bus_device.acpi_config.fs_lcnt = 0xa0;
-        bus_device.acpi_config.sda_hold = 0x9;
     } else {
         IOLog("%s::%s Got bus configuration values\n", getName(), bus_device.name);
     }


### PR DESCRIPTION
Hi devs!

This PR allows accepting a single set of bus `*CNT` values (`hcnt`, `lcnt`, and `sda hold`) for a certain bus frequency (Standard Mode and Fast Mode) and leaves the missing sets as default. Which will actually reflect the log that says "using defaults where necessary".

https://github.com/VoodooI2C/VoodooI2C/blob/9ddc72ab7e3ff1007a534dc425977fd7d7d298a3/VoodooI2C/VoodooI2C/VoodooI2CController/VoodooI2CControllerDriver.cpp#L468

Previously if one set of the `*CNT` values for a certain frequency is missing, all of the values will be set back to default. This is problematic on platforms where the OEM only provides a set of customized values for the desired frequency and leaves others unset.

Here is an example from an ASUS laptop (Zephyrus S GX531GS):

```asl
// Line 60904
Scope (_SB.PCI0.I2C1)
{
    // Only FMCN is provided
    Method (FMCN, 0, NotSerialized)
    {
        Name (PKG, Package (0x03)
        {
            0x0101, 
            0x012C, 
            0x62
        })
        Return (PKG)
    }
    Device (ETPD)
    {
        Name (SBFB, ResourceTemplate ()
        {                                                // 0x61A80 is 400KHz, Fast Mode
            I2cSerialBusV2 (0x004C, ControllerInitiated, 0x00061A80,
                AddressingMode7Bit, "\\_SB.PCI0.I2C1",
                0x00, ResourceConsumer, _Y34, Exclusive,
                )
        })
        Name (SBFI, ResourceTemplate ()
        {
            Interrupt (ResourceConsumer, Level, ActiveHigh, Exclusive, ,, )
            {
                0x0000005F,
            }
        })
        // ...
```

Original DSDT for reference:
[DSDT.aml.zip](https://github.com/VoodooI2C/VoodooI2C/files/7140824/DSDT.aml.zip)

---

BTW, I realized that the controller code is ported from the Linux DesignWare I2C driver and there is a way to read the tx and rx fifo depth. Currently the tx and rx fifo depth is hardcoded, is there any particular reason for that?

https://github.com/torvalds/linux/blob/bf9f243f23e6623f310ba03fbb14e10ec3a61290/drivers/i2c/busses/i2c-designware-common.c#L572-L598

Thanks and have a nice day.
