### PR TITLE
Display interrupt type in IOReg

### DIFF
--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -19,6 +19,8 @@
 OSDefineMetaClassAndStructors(VoodooI2CDeviceNub, IOService);
 
 bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
+    char const *interruptMode = "Polling";
+    
     if (!super::attach(provider))
         return false;
 
@@ -44,6 +46,7 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
     }
 
     if (has_gpio_interrupts) {
+        interruptMode = "GPIO";
         gpio_controller = getGPIOController();
 
         if (!gpio_controller) {
@@ -54,8 +57,11 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
         // Give the GPIO controller some time to load
 
         IOSleep(500);
+    } else if (has_apic_interrupts) {
+        interruptMode = "APIC";
     }
 
+    setProperty("Interrupt Mode", interruptMode);
     setName(child->getName());
 
     return true;

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -55,6 +55,7 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
 
         // Give the GPIO controller some time to load
         IOSleep(500);
+
         interruptMode = "GPIO";
     } else if (has_apic_interrupts) {
         interruptMode = "APIC";

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -19,8 +19,8 @@
 OSDefineMetaClassAndStructors(VoodooI2CDeviceNub, IOService);
 
 bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
-    const char *interruptMode;
-    
+    const char *interruptMode = nullptr;
+
     if (!super::attach(provider))
         return false;
 
@@ -55,7 +55,7 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
 
         // Give the GPIO controller some time to load
         IOSleep(500);
-        
+
         interruptMode = "GPIO";
     } else if (has_apic_interrupts) {
         interruptMode = "APIC";

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -55,7 +55,6 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
 
         // Give the GPIO controller some time to load
         IOSleep(500);
-
         interruptMode = "GPIO";
     } else if (has_apic_interrupts) {
         interruptMode = "APIC";

--- a/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
+++ b/VoodooI2C/VoodooI2C/VoodooI2CDevice/VoodooI2CDeviceNub.cpp
@@ -19,7 +19,7 @@
 OSDefineMetaClassAndStructors(VoodooI2CDeviceNub, IOService);
 
 bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
-    char const *interruptMode = "Polling";
+    const char *interruptMode;
     
     if (!super::attach(provider))
         return false;
@@ -46,7 +46,6 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
     }
 
     if (has_gpio_interrupts) {
-        interruptMode = "GPIO";
         gpio_controller = getGPIOController();
 
         if (!gpio_controller) {
@@ -55,10 +54,13 @@ bool VoodooI2CDeviceNub::attach(IOService* provider, IOService* child) {
         }
 
         // Give the GPIO controller some time to load
-
         IOSleep(500);
+        
+        interruptMode = "GPIO";
     } else if (has_apic_interrupts) {
         interruptMode = "APIC";
+    } else {
+        interruptMode = "Polling";
     }
 
     setProperty("Interrupt Mode", interruptMode);


### PR DESCRIPTION
It's a little hard sometimes to figure out whether VoodooI2C is polling or using APIC/GPIO interrupts without looking at logs. This provides a quick way to figure out what mode is being used. Solves #487 

Sorry for the messy commits, was from me fooling around with VoodooI2CHID at the same time.