### PR TITLE
Fix multiple issues with clicking

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -114,7 +114,7 @@ bool VoodooI2CNativeEngine::start(IOService* provider) {
         return false;
     }
     
-    voodooInputInstance = NULL;
+    voodooInputInstance = nullptr;
     
     setProperty(VOODOO_INPUT_LOGICAL_MAX_X_KEY, parentProvider->logical_max_x, 32);
     setProperty(VOODOO_INPUT_LOGICAL_MAX_Y_KEY, parentProvider->logical_max_y, 32);
@@ -153,15 +153,15 @@ bool VoodooI2CNativeEngine::isForceClickEnabled() {
             if (key->isEqualTo("Clicking")) {
                 OSBoolean *boolValue;
                 OSNumber *numValue;
-                if ((boolValue = OSDynamicCast(OSBoolean, dict->getObject(key))) != NULL) {
+                if ((boolValue = OSDynamicCast(OSBoolean, dict->getObject(key))) != nullptr) {
                     if (!boolValue->getValue()) {
-                        lastIsForceClickEnabled = FALSE;
+                        lastIsForceClickEnabled = false;
                         break;
                     }
                 }
                 // is it needed? in default properties it's number, not boolean
-                else if ((numValue = OSDynamicCast(OSNumber, dict->getObject(key))) != NULL && !numValue->unsigned64BitValue()) {
-                    lastIsForceClickEnabled = FALSE;
+                else if ((numValue = OSDynamicCast(OSNumber, dict->getObject(key))) != nullptr && !numValue->unsigned64BitValue()) {
+                    lastIsForceClickEnabled = false;
                     break;
                 }
             }
@@ -170,7 +170,7 @@ bool VoodooI2CNativeEngine::isForceClickEnabled() {
             if (key->isEqualTo("ForceSuppressed")) {
                 OSBoolean* value = OSDynamicCast(OSBoolean, dict->getObject(key));
 
-                if (value != NULL) {
+                if (value != nullptr) {
                     lastIsForceClickEnabled = !value->getValue();
                 }
             }
@@ -204,7 +204,7 @@ bool VoodooI2CNativeEngine::handleOpen(IOService *forClient, IOOptionBits option
 }
 
 bool VoodooI2CNativeEngine::handleIsOpen(const IOService *forClient) const {
-    return voodooInputInstance != NULL && forClient == voodooInputInstance;
+    return voodooInputInstance != nullptr && forClient == voodooInputInstance;
 }
 
 void VoodooI2CNativeEngine::handleClose(IOService *forClient, IOOptionBits options) {

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.hpp
@@ -27,7 +27,7 @@ class EXPORT VoodooI2CNativeEngine : public VoodooI2CMultitouchEngine {
     VoodooI2CMultitouchInterface* parentProvider;
     IOService* voodooInputInstance;
 
-    bool lastIsForceClickEnabled = true;
+    bool lastIsForceClickEnabled = false;
     AbsoluteTime lastForceClickPropertyUpdateTime;
 
     bool isForceClickEnabled();

--- a/Multitouch Support/VoodooI2CDigitiserTransducer.hpp
+++ b/Multitouch Support/VoodooI2CDigitiserTransducer.hpp
@@ -90,6 +90,7 @@ class EXPORT VoodooI2CDigitiserTransducer : public OSObject {
     
 public:
     DigitiserTransducerButtonState physical_button;
+    bool has_secondary_button = false;
     
     DigitiserTransducerCoordinates coordinates;
     DigitiserTransducerCoordinates last_coordinates;


### PR DESCRIPTION
1. Always pass buttons as pressure on single-button touchpads (fix #496)
2. Always disable Force Touch and pass buttons to buttons device on touchpads with two physical buttons (fixes inability to click without finger on the touchpad (#499) and inability to use the right button with default settings)
3. Disable Force Touch on all touchpads if tap to click is disabled (fixes inability to make a non-force click with default settings, especially in Recovery where there is no System Preferences application)