### PR TITLE
Add confidence bit for palm rejection

### DIFF
--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -30,6 +30,7 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
 
     int valid_touch_count = 0;
 
+    IOLog("I2C Contact Count: %d\n", event.contact_count);
     for (int i = 0; i < event.contact_count; i++) {
         VoodooI2CDigitiserTransducer* transducer = (VoodooI2CDigitiserTransducer*) event.transducers->getObject(i+stylus_check);
         VoodooInputTransducer* inputTransducer = &message.transducers[i];
@@ -47,6 +48,11 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
         if (inputTransducer->isValid) {
             valid_touch_count++;
         }
+        
+        if (!transducer->confidence.value()) {
+            inputTransducer->fingerType = static_cast<MT2FingerType>(6);
+        }
+        
         inputTransducer->isTransducerActive = transducer->tip_switch.value();
         inputTransducer->isPhysicalButtonDown = !transducer->has_secondary_button && transducer->physical_button.value(); // if it has secondary button, then it will be passed as buttons on the "trackpoint" device
         
@@ -74,6 +80,8 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
             inputTransducer->currentCoordinates.pressure = 0xff;
             inputTransducer->currentCoordinates.width = 10;
         }
+        
+        IOLog("I2C [%i] - Valid: %d - Confidence: %d - Tip Switch: %d\n", i, transducer->is_valid, transducer->confidence.value(), transducer->tip_switch.value());
     }
     
     // set the thumb to improve 4F pinch and spread gesture and cross-screen dragging

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -49,7 +49,7 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
         }
         
         if (!transducer->confidence.value()) {
-            inputTransducer->fingerType = static_cast<MT2FingerType>(6);
+            inputTransducer->fingerType = kMT2FingerTypePalm;
         }
         
         inputTransducer->isTransducerActive = transducer->tip_switch.value();

--- a/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
+++ b/Multitouch Support/Native/VoodooI2CNativeEngine.cpp
@@ -30,7 +30,6 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
 
     int valid_touch_count = 0;
 
-    IOLog("I2C Contact Count: %d\n", event.contact_count);
     for (int i = 0; i < event.contact_count; i++) {
         VoodooI2CDigitiserTransducer* transducer = (VoodooI2CDigitiserTransducer*) event.transducers->getObject(i+stylus_check);
         VoodooInputTransducer* inputTransducer = &message.transducers[i];
@@ -80,8 +79,6 @@ MultitouchReturn VoodooI2CNativeEngine::handleInterruptReport(VoodooI2CMultitouc
             inputTransducer->currentCoordinates.pressure = 0xff;
             inputTransducer->currentCoordinates.width = 10;
         }
-        
-        IOLog("I2C [%i] - Valid: %d - Confidence: %d - Tip Switch: %d\n", i, transducer->is_valid, transducer->confidence.value(), transducer->tip_switch.value());
     }
     
     // set the thumb to improve 4F pinch and spread gesture and cross-screen dragging

--- a/Multitouch Support/VoodooI2CDigitiserTransducer.cpp
+++ b/Multitouch Support/VoodooI2CDigitiserTransducer.cpp
@@ -41,6 +41,9 @@ VoodooI2CDigitiserTransducer* VoodooI2CDigitiserTransducer::transducer(Digitiser
     transducer->collection  = digitizer_collection;
     transducer->in_range    = false;
 
+    // Set Confidence bit for satellites which do not implement contact rejection yet
+    transducer->confidence.update(1, 0);
+
 exit:
     return transducer;
 }

--- a/Multitouch Support/VoodooI2CDigitiserTransducer.hpp
+++ b/Multitouch Support/VoodooI2CDigitiserTransducer.hpp
@@ -101,6 +101,7 @@ public:
     DigitiserTransducerAziAltiOrentation azi_alti_orientation;
     DigitiserTransducerTiltOrientation tilt_orientation;
     
+    DigitiserTransducerButtonState confidence;
     DigitiserTransducerButtonState tip_switch;
     TimeTrackedValue tip_pressure;
     


### PR DESCRIPTION
I was parsing the MT2 output for some other projects and came across a new finger ID. This seems to only be sent when the touchpad detects a palm. This seems to map well to the confidence bit sent by Precision/HID touchpads, and allow for rejecting contacts based off of size relatively easily.

This does break every satellite since the Transducer class is modified, so some caution is needed before trying to merge this in.

Companion ELAN implementation:
https://github.com/1Revenger1/VoodooI2CELAN/pull/1

Companion HID implementation:
https://github.com/1Revenger1/VoodooI2CHID/pull/1